### PR TITLE
Update usage of actions/checkout

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
+      with:
+        submodules: true
 
     - name: Build and Deploy
       uses: solybum/hexo-deploy@master


### PR DESCRIPTION
actions/checkout excludes submodules by default and that causes the hexo deploy action to not include the submodule themes